### PR TITLE
하단 네비게이션바 화면 가리는 버그

### DIFF
--- a/src/app/ClientLayout.tsx
+++ b/src/app/ClientLayout.tsx
@@ -11,8 +11,15 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
   const shouldShowNav = showNavPaths.includes(pathname);
 
   return (
-    <div className="relative min-h-screen">
-      {children}
+    <div className="flex min-h-screen justify-center bg-gray-100">
+      {/* 메인 컨테이너 - PC에서 max-width 적용 */}
+      <div
+        className={`relative mx-auto w-full max-w-[640px] bg-white ${shouldShowNav ? "min-h-screen pb-[70px]" : "min-h-screen"}`}
+      >
+        {children}
+      </div>
+
+      {/* 하단 네비게이션바 - fixed로 전역 렌더링 */}
       {shouldShowNav && <CommonNav />}
     </div>
   );

--- a/src/app/board/question/page.tsx
+++ b/src/app/board/question/page.tsx
@@ -22,53 +22,48 @@ export default function QuestionPage() {
   };
 
   return (
-    <div className="flex min-h-screen justify-center bg-gray-100">
-      <div className="relative mx-auto min-h-screen w-full max-w-[640px] bg-white">
-        {/* Header */}
-        <Header title="질문게시판" leftType={LEFT_ITEM.BACK} onLeftClick={handleBackClick} />
+    <>
+      {/* Header */}
+      <Header title="질문게시판" leftType={LEFT_ITEM.BACK} onLeftClick={handleBackClick} />
 
-        {/* 헤더 아래 여백 추가 */}
-        <div className="mt-[40px]">
-          {/* Main Content */}
-          <main className="px-5">
-            {/* 검색바 */}
-            <section aria-label="search" className="mb-5">
-              <CommonSearchBar />
-            </section>
+      {/* Main Content */}
+      <main className="px-5 pt-4">
+        {/* 검색바 */}
+        <section aria-label="search" className="mb-5">
+          <CommonSearchBar />
+        </section>
 
-            {/* HOT 인기질문 섹션 */}
-            <section aria-labelledby="hot-questions-heading" className="mb-8">
-              <HotQuestionSection
-                activeTab={questionActiveTab}
-                onTabChange={setQuestionActiveTab}
-                onViewAll={() => router.push("/board/question")}
-              />
-            </section>
+        {/* HOT 인기질문 섹션 */}
+        <section aria-labelledby="hot-questions-heading" className="mb-8">
+          <HotQuestionSection
+            activeTab={questionActiveTab}
+            onTabChange={setQuestionActiveTab}
+            onViewAll={() => router.push("/board/question")}
+          />
+        </section>
 
-            {/* 내 전공관련 질문 섹션 */}
-            <section aria-labelledby="major-questions-heading" className="mb-8">
-              <MajorQuestionSection onViewAll={() => router.push("/board/question")} />
-            </section>
+        {/* 내 전공관련 질문 섹션 */}
+        <section aria-labelledby="major-questions-heading" className="mb-8">
+          <MajorQuestionSection onViewAll={() => router.push("/board/question")} />
+        </section>
 
-            {/* 전체 질문 섹션 */}
-            <section aria-labelledby="all-questions-heading" className="mb-8">
-              <AllQuestionListSection onViewAll={() => router.push("/board/question")} />
-            </section>
+        {/* 전체 질문 섹션 */}
+        <section aria-labelledby="all-questions-heading" className="mb-8">
+          <AllQuestionListSection onViewAll={() => router.push("/board/question")} />
+        </section>
 
-            {/* 연전현상금 섹션 */}
-            <section aria-labelledby="bounty-questions-heading" className="mb-8">
-              <BountyQuestionSection
-                activeTab={bountyActiveTab}
-                onTabChange={setBountyActiveTab}
-                onViewAll={() => router.push("/board/question")}
-              />
-            </section>
-          </main>
-        </div>
+        {/* 연전현상금 섹션 */}
+        <section aria-labelledby="bounty-questions-heading" className="mb-8">
+          <BountyQuestionSection
+            activeTab={bountyActiveTab}
+            onTabChange={setBountyActiveTab}
+            onViewAll={() => router.push("/board/question")}
+          />
+        </section>
+      </main>
 
-        {/* 플로팅 버튼 (글쓰기) */}
-        <UploadQuestionFAB isFABVisible />
-      </div>
-    </div>
+      {/* 플로팅 버튼 (글쓰기) */}
+      <UploadQuestionFAB isFABVisible />
+    </>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -75,8 +75,8 @@
 
 /* TheTuesdayofYounah 폰트 : 랜딩페이지 "세종말싸미" 폰트 */
 @font-face {
-  font-family: 'TheTuesdayofYounah';
-  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/2506-1@1.0/TheTuesdayofYounah.woff2') format('woff2');
+  font-family: "TheTuesdayofYounah";
+  src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/2506-1@1.0/TheTuesdayofYounah.woff2") format("woff2");
   font-weight: normal;
   font-style: normal;
 }
@@ -106,11 +106,21 @@
     @apply font-suit font-bold;
   }
 
-/* TheTuesdayofYounah 폰트 유틸리티 클래스 : 랜딩페이지 "세종말싸미" 폰트 */
+  /* TheTuesdayofYounah 폰트 유틸리티 클래스 : 랜딩페이지 "세종말싸미" 폰트 */
   .font-tuesday-younah {
-    font-family: 'TheTuesdayofYounah', sans-serif;
+    font-family: "TheTuesdayofYounah", sans-serif;
   }
 
+  html {
+    @apply bg-background text-foreground;
+  }
+
+  body {
+    font-synthesis: none; /* 폰트 합성 제거 */
+    font-family: "Pretendard", "Apple SD Gothic Neo", "Roboto", "Arial", sans-serif;
+    -webkit-font-smoothing: antialiased; /* iOS 텍스트 렌더링 개선 */
+    -moz-osx-font-smoothing: grayscale; /* macOS 텍스트 렌더링 개선 */
+  }
 }
 
 @layer base {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
+/* 기본 CSS 변수 */
 :root {
   --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 214, 219, 220;
@@ -16,6 +17,7 @@
   }
 }
 
+/* Pretendard 폰트 */
 @font-face {
   font-family: "Pretendard";
   font-weight: 400;
@@ -44,7 +46,7 @@
   src: url("https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Bold.woff") format("woff");
 }
 
-/* SUIT 폰트  */
+/* SUIT 폰트 */
 @font-face {
   font-family: "SUIT";
   font-weight: 400;
@@ -73,7 +75,7 @@
   src: url("https://cdn.jsdelivr.net/gh/sunn-us/SUIT/fonts/static/woff2/SUIT-Bold.woff2") format("woff2");
 }
 
-/* TheTuesdayofYounah 폰트 : 랜딩페이지 "세종말싸미" 폰트 */
+/* 랜딩페이지 로고 폰트 */
 @font-face {
   font-family: "TheTuesdayofYounah";
   src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/2506-1@1.0/TheTuesdayofYounah.woff2") format("woff2");
@@ -81,21 +83,23 @@
   font-style: normal;
 }
 
+/* 폰트 유틸리티 클래스 */
 @layer utilities {
+  /* Pretendard 폰트 클래스 */
   .font-pretendard-light {
     @apply font-pretendard font-light;
   }
-  .font-pretendard-semibold {
-    @apply font-pretendard font-semibold;
-  }
   .font-pretendard-medium {
     @apply font-pretendard font-medium;
+  }
+  .font-pretendard-semibold {
+    @apply font-pretendard font-semibold;
   }
   .font-pretendard-bold {
     @apply font-pretendard font-bold;
   }
 
-  /* SUIT 폰트 유틸리티 클래스 */
+  /* SUIT 폰트 클래스 */
   .font-suit-medium {
     @apply font-suit font-medium;
   }
@@ -106,24 +110,15 @@
     @apply font-suit font-bold;
   }
 
-  /* TheTuesdayofYounah 폰트 유틸리티 클래스 : 랜딩페이지 "세종말싸미" 폰트 */
+  /* 랜딩페이지 로고 폰트 클래스 */
   .font-tuesday-younah {
     font-family: "TheTuesdayofYounah", sans-serif;
   }
-
-  html {
-    @apply bg-background text-foreground;
-  }
-
-  body {
-    font-synthesis: none; /* 폰트 합성 제거 */
-    font-family: "Pretendard", "Apple SD Gothic Neo", "Roboto", "Arial", sans-serif;
-    -webkit-font-smoothing: antialiased; /* iOS 텍스트 렌더링 개선 */
-    -moz-osx-font-smoothing: grayscale; /* macOS 텍스트 렌더링 개선 */
-  }
 }
 
+/* 기본 스타일 */
 @layer base {
+  /* Shadcn/ui 색상 변수 */
   :root {
     --background: 0 0% 100%;
     --foreground: 0 0% 3.9%;
@@ -151,6 +146,8 @@
     --chart-5: 27 87% 67%;
     --radius: 0.5rem;
   }
+
+  /* 다크모드 색상 변수 */
   .dark {
     --background: 0 0% 3.9%;
     --foreground: 0 0% 98%;
@@ -177,23 +174,23 @@
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
   }
+
+  /* 전체 요소 기본 스타일 */
+  * {
+    @apply border-border;
+  }
+
+  /* HTML 기본 스타일 */
   html {
     @apply bg-background text-foreground;
   }
 
-  body {
-    font-synthesis: none; /* 폰트 합성 제거 */
-    font-family: "Pretendard", "Apple SD Gothic Neo", "Roboto", "Arial", sans-serif;
-    -webkit-font-smoothing: antialiased; /* iOS 텍스트 렌더링 개선 */
-    -moz-osx-font-smoothing: grayscale; /* macOS 텍스트 렌더링 개선 */
-  }
-}
-
-@layer base {
-  * {
-    @apply border-border;
-  }
+  /* Body 기본 스타일 */
   body {
     @apply bg-background text-foreground;
+    font-synthesis: none;
+    font-family: "Pretendard", "Apple SD Gothic Neo", "Roboto", "Arial", sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,62 +46,60 @@ export default function LandingPage() {
   }, []);
 
   return (
-    <div className="flex min-h-screen justify-center bg-gray-100">
-      <div className="relative mx-auto min-h-screen w-full max-w-[640px] bg-white">
-        {/* Header */}
-        <LandingHeader />
+    <>
+      {/* Header */}
+      <LandingHeader />
 
-        {/* Main Content */}
-        <main className="px-5">
-          {/* 캐릭터와 인사말 섹션 */}
-          <section aria-labelledby="welcome-heading" className="mb-6 mt-8">
-            <WelcomeSection userName={userName} />
-          </section>
+      {/* Main Content */}
+      <main className="px-5">
+        {/* 캐릭터와 인사말 섹션 */}
+        <section aria-labelledby="welcome-heading" className="mb-6 mt-8">
+          <WelcomeSection userName={userName} />
+        </section>
 
-          {/* 검색창 섹션 */}
-          <section aria-label="search" className="mb-6">
-            {/* SearchBar 컴포넌트로 분리 가능 */}
-            {/* <SearchBar /> */}
-          </section>
+        {/* 검색창 섹션 */}
+        <section aria-label="search" className="mb-6">
+          {/* SearchBar 컴포넌트로 분리 가능 */}
+          {/* <SearchBar /> */}
+        </section>
 
-          {/* 공지사항 섹션 */}
-          <section aria-labelledby="notice-heading" className="mb-6">
-            <NoticeSection onViewAll={() => router.push("/notice")} />
-          </section>
+        {/* 공지사항 섹션 */}
+        <section aria-labelledby="notice-heading" className="mb-6">
+          <NoticeSection onViewAll={() => router.push("/notice")} />
+        </section>
 
-          {/* HOT 인기자료 섹션 */}
-          <section ref={hotDocumentRef} aria-labelledby="hot-documents-heading" className="mb-8">
-            <HotDocumentsSection
-              activeTab={documentActiveTab}
-              onTabChange={setDocumentActiveTab}
-              onViewAll={() => router.push("/board/document/hot")}
-            />
-          </section>
+        {/* HOT 인기자료 섹션 */}
+        <section ref={hotDocumentRef} aria-labelledby="hot-documents-heading" className="mb-8">
+          <HotDocumentsSection
+            activeTab={documentActiveTab}
+            onTabChange={setDocumentActiveTab}
+            onViewAll={() => router.push("/board/document/hot")}
+          />
+        </section>
 
-          {/* 전체 자료 게시판 섹션 */}
-          <section aria-labelledby="all-documents-heading" className="mb-8">
-            <AllDocumentsSection onViewAll={() => router.push("/board/document")} />
-          </section>
+        {/* 전체 자료 게시판 섹션 */}
+        <section aria-labelledby="all-documents-heading" className="mb-8">
+          <AllDocumentsSection onViewAll={() => router.push("/board/document")} />
+        </section>
 
-          {/* HOT 인기질문 섹션 */}
-          <section ref={hotQuestionRef} aria-labelledby="hot-questions-heading" className="mb-8">
-            <HotQuestionsSection
-              activeTab={questionActiveTab}
-              onTabChange={setQuestionActiveTab}
-              onViewAll={() => router.push("/board/question")}
-            />
-          </section>
+        {/* HOT 인기질문 섹션 */}
+        <section ref={hotQuestionRef} aria-labelledby="hot-questions-heading" className="mb-8">
+          <HotQuestionsSection
+            activeTab={questionActiveTab}
+            onTabChange={setQuestionActiveTab}
+            onViewAll={() => router.push("/board/question")}
+          />
+        </section>
 
-          {/* 전체 질문 게시판 섹션 */}
-          <section aria-labelledby="all-questions-heading" className="mb-8">
-            {/* AllQuestionsSection 컴포넌트로 분리 가능 */}
-            <AllQuestionsSection onViewAll={() => router.push("/board/question")} />
-          </section>
-        </main>
+        {/* 전체 질문 게시판 섹션 */}
+        <section aria-labelledby="all-questions-heading" className="mb-8">
+          {/* AllQuestionsSection 컴포넌트로 분리 가능 */}
+          <AllQuestionsSection onViewAll={() => router.push("/board/question")} />
+        </section>
+      </main>
 
-        {/* 플로팅 버튼 (글쓰기) */}
-        <LandingWriteFAB />
-      </div>
-    </div>
+      {/* 플로팅 버튼 (글쓰기) */}
+      <LandingWriteFAB />
+    </>
   );
 }

--- a/src/components/common/CommonNav.tsx
+++ b/src/components/common/CommonNav.tsx
@@ -15,7 +15,7 @@ function CommonNav() {
   ];
 
   return (
-    <nav className="h-15 fixed bottom-0 flex w-full items-end justify-between bg-white px-9 py-[10px] shadow-[0_-2px_6px_rgba(0,0,0,0.1)]">
+    <nav className="fixed bottom-0 left-1/2 z-50 flex h-[70px] w-full max-w-[640px] -translate-x-1/2 transform items-end justify-between bg-white px-9 py-[10px] shadow-[0_-2px_6px_rgba(0,0,0,0.1)]">
       {menuItems.map(item => {
         const isActive = pathname === item.href; // 현재 페이지 여부 확인
 

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -21,6 +21,8 @@ interface HeaderProps {
   onRightClick?: () => void;
   // eslint-disable-next-line react/require-default-props
   hasNotification?: boolean;
+  // eslint-disable-next-line react/require-default-props
+  isFixed?: boolean; // 고정 헤더 여부
 }
 
 function Header({
@@ -30,6 +32,7 @@ function Header({
   onLeftClick = () => {},
   onRightClick = () => {},
   hasNotification = false,
+  isFixed = false,
 }: HeaderProps) {
   // 왼쪽 아이콘 결정
   const renderLeftItem = () => {
@@ -57,8 +60,12 @@ function Header({
     }
   };
 
+  const headerClasses = isFixed
+    ? "fixed top-0 left-1/2 transform -translate-x-1/2 w-full max-w-[640px] z-50 flex h-16 items-center justify-between bg-white px-5 shadow-md"
+    : "flex h-16 items-center justify-between bg-white px-5 shadow-md";
+
   return (
-    <header className="flex h-16 items-center justify-between bg-white px-5 shadow-md">
+    <header className={headerClasses}>
       {/* 왼쪽 영역 */}
       <div className="flex items-center">
         {leftType === LEFT_ITEM.LOGO ? (


### PR DESCRIPTION
#518 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 헤더 컴포넌트에 상단 고정 옵션(isFixed)을 추가하여 필요 시 헤더를 화면 상단에 고정할 수 있습니다.
- **스타일**
	- 전체 레이아웃이 가운데 정렬 및 최대 너비 제한으로 개선되어, 주요 콘텐츠가 더욱 집중되도록 변경되었습니다.
	- 내비게이션 바가 화면 하단 중앙에 고정되며, 최대 너비와 z-인덱스가 적용되어 다른 요소 위에 표시됩니다.
	- CSS가 정리되고 주석이 추가되어 가독성과 일관성이 향상되었습니다.
- **리팩터**
	- 페이지 및 레이아웃 구조가 단순화되어 불필요한 중첩 div가 제거되고, 주요 섹션만 렌더링되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->